### PR TITLE
fix: cleanup test_utils

### DIFF
--- a/src/poetry_plugin_pypi_proxy/utils.py
+++ b/src/poetry_plugin_pypi_proxy/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import re
 
 
 def get_repo_id(repo_url: str) -> str:
@@ -15,10 +16,4 @@ def get_repo_id(repo_url: str) -> str:
 
 def parse_url(url: str) -> str:
     """Remove suffix from url appropriately so it can be used by the proxy object."""
-    to_remove = ["simple", "simple/"]
-    for rem in to_remove:
-        if url.endswith(rem):
-            new_url = url[: -len(rem)]
-            break
-
-    return new_url
+    return re.sub("/?(simple/?)?$", "", url)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from poetry_plugin_pypi_proxy.utils import parse_url

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,20 +1,30 @@
+import pytest
+
 from poetry_plugin_pypi_proxy.utils import parse_url
 
 
-def test_parse_url():
-    input_urls = [
-        "http://proxy.org/pypi/simple",
-        "http://proxy.org/pypi/simple/",
-        "http://proxy.org/pypi/simple/simple",
-        "http://proxy.org/pypi/simple/simple/",
-    ]
-    expected_urls = [
-        "http://proxy.org/pypi/",
-        "http://proxy.org/pypi/",
-        "http://proxy.org/pypi/simple/",
-        "http://proxy.org/pypi/simple/",
-    ]
-
-    for input_url, expected_url in zip(input_urls, expected_urls):
+@pytest.mark.parametrize(
+    ["input_urls", "expected_url"],
+    [
+        (
+            [
+                "http://proxy.org/pypi",
+                "http://proxy.org/pypi/",
+                "http://proxy.org/pypi/simple",
+                "http://proxy.org/pypi/simple/",
+            ],
+            "http://proxy.org/pypi",
+        ),
+        (
+            [
+                "http://proxy.org/pypi/simple/simple",
+                "http://proxy.org/pypi/simple/simple/",
+            ],
+            "http://proxy.org/pypi/simple",
+        ),
+    ],
+)
+def test_parse_url(input_urls: list[str], expected_url: str) -> None:
+    for input_url in input_urls:
         actual_url = parse_url(input_url)
         assert actual_url == expected_url

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,19 +2,19 @@ from poetry_plugin_pypi_proxy.utils import parse_url
 
 
 def test_parse_url():
-    input = [
+    input_urls = [
         "http://proxy.org/pypi/simple",
         "http://proxy.org/pypi/simple/",
         "http://proxy.org/pypi/simple/simple",
         "http://proxy.org/pypi/simple/simple/",
     ]
-    expected = [
+    expected_urls = [
         "http://proxy.org/pypi/",
         "http://proxy.org/pypi/",
         "http://proxy.org/pypi/simple/",
         "http://proxy.org/pypi/simple/",
     ]
 
-    for index in range(len(input)):
-        actual = parse_url(input[index])
-        assert actual == expected[index]
+    for input_url, expected_url in zip(input_urls, expected_urls):
+        actual_url = parse_url(input_url)
+        assert actual_url == expected_url


### PR DESCRIPTION
Minor cleanup to avoid call to `range(len())`. Fixes a previous issue with the code that would lead to an error when the `simple` postfix was missing.