### PR TITLE
fix: simplify compatiblity checks

### DIFF
--- a/.github/workflows/compatibility.yaml
+++ b/.github/workflows/compatibility.yaml
@@ -7,8 +7,8 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.python-version }} / ${{ matrix.poetry-version }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2022, macos-12]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.12"]
         poetry-version:
           - "git+https://github.com/python-poetry/poetry.git"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
* python 3.13 isn't on GH actions yet, so removing that
* simplify number of tests... I don't really think platform will affect anything