### PR TITLE
fix: Priority.DEFAULT -> Priority.PRIMARY

### DIFF
--- a/src/poetry_plugin_pypi_proxy/plugin.py
+++ b/src/poetry_plugin_pypi_proxy/plugin.py
@@ -109,7 +109,7 @@ class PypiProxyPlugin(Plugin):
             LegacyProxyRepository(
                 name=proxy_id, url=f"{proxy_url}/simple/", config=poetry.config
             ),
-            priority=Priority.DEFAULT,
+            priority=Priority.PRIMARY,
         )
 
         # If this is a publish command to Pypi, we'll silenly redirect to the proxy


### PR DESCRIPTION
* it appears that the default priority has been removed
* since this is supposed to be a proxy for what pypi uses, change this to primary
* TODO: maybe make this a flag