### PR TITLE
fix: `PluginManager.add_plugin` -> `PluginManager._add_plugin`

### DIFF
--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -45,7 +45,12 @@ class MockApplication(Application):
             return
 
         manager = PluginManager(ApplicationPlugin.group)
-        manager.add_plugin(PypiProxyPlugin())
+        try:
+            # TODO: _add_plugin is used in 2.0+. Remove add_plugin when
+            # it's upgraded
+            manager.add_plugin(PypiProxyPlugin())
+        except AttributeError:
+            manager._add_plugin(PypiProxyPlugin())
 
         self._plugins_loaded = True
 


### PR DESCRIPTION
* Used in our e2e tests, looks like this was changed upstream to a private method
* Since this is a test I'll continue to use the private method